### PR TITLE
add required (node.js) in correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ useful if you want some customizations or if you want to submit a bugfix.
 
 * Have Java Development Kit (JDK) version 14+ installed.
 * have npm installed (`sudo apt install npm`)
+* have node.js 16.10.0 installed and defined (`nvm install 16.10.0 nvm use 16.10.0`) . 
+    * If you don't have nvm installed or it's not working properly: (`sudo apt install nvm`) .
+    * If the nvm command is not recognized in the terminal, add in bash: (`echo 'source /usr/share/nvm/init-nvm.sh' >> ~/.zshrc
+source ~/.zshrc`)
 * run the following command to disable Vaadin Gradle usage reporting (to avoid a failing NPM "integrity" check):
 ```
     npm explore @vaadin/vaadin-usage-statistics -- npm run disable


### PR DESCRIPTION
to run the command: ./gradlew clean build -Pvaadin.productionMode node.js must be in an outdated version (16.10.0). The new versions have the following error:
FAILURE: Build failed with an exception.

What went wrong: Execution failed for task ':webui:vaadinBuildFrontend'.
Command '/usr/local/bin/node /home/john/Downloads/taskadapter/webui/node_modules/webpack/bin/webpack.js' failed with exit code 1: node:internal/crypto/hash:71
this[kHandle] = new _Hash(algorithm, xofLen);
^

Error: error:0308010C:digital envelope routines::unsupported
at new Hash (node:internal/crypto/hash:71:19)
at Object.createHash (node:crypto:140:10)
at module.exports

with this, it is possible to build the program correctly